### PR TITLE
53 rviz does not found camera info not found

### DIFF
--- a/src/gstreamer/main.py
+++ b/src/gstreamer/main.py
@@ -184,11 +184,12 @@ def thread_ros_fun(teleop_wrapper: TeleopWrapper, asyncio_loop: asyncio.Abstract
     executor.add_node(rospublisher_right_cam)
     executor_thread = Thread(target=executor.spin, daemon=True)
     executor_thread.start()
+    # Note : this loop takes most of the CPU usage. see ros_publisher.py
     while True:
         data, latency, _ = teleop_wrapper.get_data_mjpeg()
         rospublisher_left_cam.publish_img(data["left_mjpeg"].tobytes(), latency["left_mjpeg"].microseconds * 1000)
         rospublisher_right_cam.publish_img(data["right_mjpeg"].tobytes(), latency["right_mjpeg"].microseconds * 1000)
-        time.sleep(0.01)
+        time.sleep(0.03)  # ~30 fps
     # executor.shutdown()
 
 

--- a/src/gstreamer/ros_publisher.py
+++ b/src/gstreamer/ros_publisher.py
@@ -24,7 +24,7 @@ class ROSPublisher(Node):  # type: ignore[misc]
         self._compr_img.format = "jpeg"
         self._compr_img.header.frame_id = f"{side}_camera_optical"
 
-        self._camera_info_publisher = self.create_publisher(CameraInfo, f"teleop_camera/{self._side}_image/camera_info", 5)
+        self._camera_info_publisher = self.create_publisher(CameraInfo, f"teleop_camera/{self._side}_image/image_raw/camera_info", 5)
         self._logger.info(f'Launching "{self._camera_info_publisher.topic_name}" publisher.')
 
         self._camera_info = CameraInfo()

--- a/src/gstreamer/ros_publisher.py
+++ b/src/gstreamer/ros_publisher.py
@@ -49,7 +49,7 @@ class ROSPublisher(Node):  # type: ignore[misc]
         offset_duration = Duration(nanoseconds=latency_ns)
         ts = self._clock.now() - offset_duration
         self._compr_img.header.stamp = ts.to_msg()
-        self._compr_img.data = frame
+        self._compr_img.data = frame  # Note: there is probably a copy here, hence the high CPU usage
         self._camera_publisher.publish(self._compr_img)
 
     async def _publish_camera_info(self, side: str) -> None:

--- a/src/gstreamer/ros_publisher.py
+++ b/src/gstreamer/ros_publisher.py
@@ -24,7 +24,9 @@ class ROSPublisher(Node):  # type: ignore[misc]
         self._compr_img.format = "jpeg"
         self._compr_img.header.frame_id = f"{side}_camera_optical"
 
-        self._camera_info_publisher = self.create_publisher(CameraInfo, f"teleop_camera/{self._side}_image/image_raw/camera_info", 5)
+        self._camera_info_publisher = self.create_publisher(
+            CameraInfo, f"teleop_camera/{self._side}_image/image_raw/camera_info", 5
+        )
         self._logger.info(f'Launching "{self._camera_info_publisher.topic_name}" publisher.')
 
         self._camera_info = CameraInfo()


### PR DESCRIPTION
start core in dev mode with this branch for the SDK server https://github.com/pollen-robotics/reachy2_sdk_server/issues/184

cameras teleop images should be displayed in rviz